### PR TITLE
Add option to set shebang line to StubGenerator

### DIFF
--- a/src/lib/Herrera/Box/StubGenerator.php
+++ b/src/lib/Herrera/Box/StubGenerator.php
@@ -282,7 +282,7 @@ STUB;
      *
      * @return StubGenerator The stub generator.
      */
-    public function setShebang($shebang)
+    public function shebang($shebang)
     {
         $this->shebang = $shebang;
 

--- a/src/tests/Herrera/Box/Tests/StubGeneratorTest.php
+++ b/src/tests/Herrera/Box/Tests/StubGeneratorTest.php
@@ -170,9 +170,9 @@ STUB
         );
     }
 
-    public function testSetShebang()
+    public function testShebang()
     {
-        $this->generator->setShebang('#!/bin/php');
+        $this->generator->shebang('#!/bin/php');
 
         $this->assertEquals(
             '#!/bin/php',


### PR DESCRIPTION
This patch adds an optional `setShebang($shebang)` method to the `StubGenerator` in order to overwrite the default shebang.

In particular, this is useful for custom setups where `/usr/bin/env` is not available or if it's required to pass additional arguments to the php interpreter (like `#!/usr/bin/php -q`).
