### PR TITLE
Always call Phar::mapPhar() even when no alias has been set

### DIFF
--- a/src/lib/Herrera/Box/StubGenerator.php
+++ b/src/lib/Herrera/Box/StubGenerator.php
@@ -234,9 +234,7 @@ class StubGenerator
             $stub[] = 'if (class_exists(\'Phar\')) {';
         }
 
-        if ($this->alias) {
-            $stub[] = $this->getAlias();
-        }
+        $stub[] = $this->getAlias();
 
         if ($this->intercept) {
             $stub[] = "Phar::interceptFileFuncs();";

--- a/src/tests/Herrera/Box/Tests/StubGeneratorTest.php
+++ b/src/tests/Herrera/Box/Tests/StubGeneratorTest.php
@@ -55,6 +55,7 @@ does work
  *
  *   indented
  */
+Phar::mapPhar('');
 __HALT_COMPILER();
 STUB
             ,


### PR DESCRIPTION
This simple PR makes sure to always include a call to `Phar::mapPhar()`. This call is needed if you rename your resulting phar file and remove its file extension. Removing the file extension is often used when moving _local_ phars to systems wide installations, e.g. when renaming `~/demo.phar` to `/usr/bin/demo`.
