### PR TITLE
Optimize build speed by 97% or more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "php": ">=5.3.3",
         "ext-phar": "*",
         "tedivm/jshrink": "~1.0",
-        "phine/path": "~1.0"
+        "phine/path": "~1.0",
+        "symfony/filesystem": "3.4"
     },
     "require-dev": {
         "herrera-io/annotations": "~1.0",


### PR DESCRIPTION
Hi there!

My colleague informed me that building the phar file takes about 4 minutes. I couldn't believe this so I quickly looked into what the issue was. Blackfire told me 97% of all the time is needed at `Phar::addFromString()`. So I thought why not just write it all to a temporary directory, make it "lazy" and then add all of the files to the phar file at once using `Phar::buildFromDirectory()`.
Turns out this works just fine for me and build time went down from 4 min 5 s to 7.05 s 😎 

I couldn't add tests because the supported php versions and the used phpunit is so old that I sort of cannot get it to work without some serious changes. Do you plan to update the tests on master and update to a decent phpunit version? If so, I'll be happy to add tests for this stuff here.

Hope to help :-)

PS: Blackfire comparison: https://blackfire.io/profiles/compare/2d79d513-2460-4010-a797-914ba7237a7f/graph